### PR TITLE
The app is only a lib, remove erroneous mod field

### DIFF
--- a/src/ssl_verify_hostname.app.src
+++ b/src/ssl_verify_hostname.app.src
@@ -9,7 +9,6 @@
                   stdlib,
                   ssl
                  ]},
-  {mod, { ssl_verify_hostname_app, []}},
   {env, []}
  ]}.
 


### PR DESCRIPTION
Hello Benoit,
Small error in the `ssl_verify_hostname` app which breaks release creation with static embedded erlang start script containing hackney.
The `ssl_verify_hostname_app` module does not exist and no supervision tree has to be launched for this app.

Have a good day.

Arnaud
